### PR TITLE
Update Computation.py

### DIFF
--- a/pygpc/Computation.py
+++ b/pygpc/Computation.py
@@ -141,7 +141,7 @@ class ComputationPoolMap:
 
         # deepcopy model and delete attributes
         model_ = copy.deepcopy(model)
-        model_.__clean__()
+        # model_.__clean__()
 
         for j, random_var_instances in enumerate(grid_new):
 


### PR DESCRIPTION
The operation to clean the model after performing a deepcopy has been canceled. The clean model operation removes all attributes of the model, which leads to the inability to initialize TES.